### PR TITLE
fixed connectivity_terms and anatomicall_map

### DIFF
--- a/anatomical_map.json
+++ b/anatomical_map.json
@@ -320,11 +320,11 @@
         "name": "Bronchus"
     },
     "respiratory_26": {
-        "term": "FMA:67480",
+        "term": "ILX:0793764",
         "name": "Wall of Bronchus"
     },
     "respiratory_27": {
-        "term": "FMA:74655",
+        "term": "ILX:0793764",
         "name": "Wall of Bronchiole"
     },
 	"respiratory_28": {

--- a/connectivity_terms_female.json
+++ b/connectivity_terms_female.json
@@ -1043,7 +1043,7 @@
     },
     {
         "id": [
-            "ILX:0788968",
+            "UBERON:0002364",
             []
         ],
         "aliases": [
@@ -1052,7 +1052,7 @@
                 []
             ]
         ],
-        "name": "vagal branch to tympanic membrane"
+        "name": "tympanic membrane"
     },
     {
         "id": [

--- a/connectivity_terms_male.json
+++ b/connectivity_terms_male.json
@@ -1070,7 +1070,7 @@
     },
     {
         "id": [
-            "ILX:0788968",
+            "UBERON:0002364",
             []
         ],
         "aliases": [
@@ -1079,7 +1079,7 @@
                 []
             ]
         ],
-        "name": "vagal branch to tympanic membrane"
+        "name": "tympanic membrane"
     },
     {
         "id": [


### PR DESCRIPTION
There are three fixes:

- Replace FMA:67480 with ILX:0793764
- Replace FMA:74655 with ILX:0793764
- Replace an alias from ILX:0788968 `vagal branch to tympanic membrane` to ILX:0788968 `tympanic membrane`
- Updating annotation in male svg male from urinary_15-1 `Rhabdosphincter of female` to urinary_17-1 `Rhabdosphincter of male`