### PR TITLE
Rename 'centrelines' field to 'no-centrelines' and remove overlapping segments from 'features'

### DIFF
--- a/properties.json
+++ b/properties.json
@@ -6080,115 +6080,16 @@
             "type": "nerve",
             "models": "ILX:0793632"
         },
-        "bolser_11": {
-            "class": "bolser_5"
-        },
-        "bolser_25": {
-            "class": "bolser_5"
-        },
-        "vagus_n-1": {
-            "class": "vagus_n"
-        },
-        "vagus_n-2": {
-            "class": "vagus_n"
-        },
-        "vagus_n-3": {
-            "class": "vagus_n"
-        },
-        "vagus_n-4": {
-            "class": "vagus_n"
-        },
-        "vagus_n-5": {
-            "class": "vagus_n"
-        },
-        "vagus_n-6": {
-            "class": "vagus_n"
-        },
-        "vagus_n-7": {
-            "class": "vagus_n"
-        },
-        "vagus_n-8": {
-            "class": "vagus_n"
-        },
-        "vagus_n-9": {
-            "class": "vagus_n"
-        },
-        "vagus_n-10": {
-            "class": "vagus_n"
-        },
-        "vagus_n-11": {
-            "class": "vagus_n"
-        },
-        "vagus_n-12": {
-            "class": "vagus_n"
-        },
-        "vagus_n-13": {
-            "class": "vagus_n"
-        },
-        "vagus_n-14": {
-            "class": "vagus_n"
-        },
         "vagus": {
             "class": "vagus_n",
             "type": "nerve"
-        },
-        "vagus_n_m-1": {
-            "class": "vagus_n"
-        },
-        "vagus_n_m-2": {
-            "class": "vagus_n"
-        },
-        "vagus_n_m-3": {
-            "class": "vagus_n"
-        },
-        "vagus_n_m-4": {
-            "class": "vagus_n"
-        },
-        "vagus_n_m-5": {
-            "class": "vagus_n"
-        },
-        "vagus_n_m-6": {
-            "class": "vagus_n"
-        },
-        "vagus_n_m-7": {
-            "class": "vagus_n"
-        },
-        "vagus_n_m-8": {
-            "class": "vagus_n"
-        },
-        "vagus_n_m-9": {
-            "class": "vagus_n"
-        },
-        "vagus_n_m-10": {
-            "class": "vagus_n"
-        },
-        "vagus_n_m-11": {
-            "class": "vagus_n"
-        },
-        "vagus_n_m-12": {
-            "class": "vagus_n"
-        },
-        "vagus_n_m-13": {
-            "class": "vagus_n"
-        },
-        "vagus_n_m-14": {
-            "class": "vagus_n"
-        },
-        "vagus_n_m-15": {
-            "class": "vagus_n"
-        },
-        "vagus_n_m-16": {
-            "class": "vagus_n"
-        },
-        "vagus_n_m-17": {
-            "class": "vagus_n"
         }
     },
     "networks": [
         {
             "id": "neural",
             "type": "nerve",
-            "centrelines": [
+            "no-centrelines": [
                 {
                     "id": "n_6",
                     "models": "ILX:0793828",


### PR DESCRIPTION
This PR addresses issue #46.

- Renames the `centrelines` field to `no-centrelines`.
- Removes segments listed in `features` which also listed in `no-centrelines` to prevent missing lines during rendering.

Proposed to be merged into the curation branch.